### PR TITLE
Added benchmarks and pretty printer

### DIFF
--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -1,0 +1,43 @@
+-- | This module contains the benchmark test to quantify the time
+-- performance of the simple-sat library functions.
+module Main( main ) where
+
+import Prelude hiding (and,or,not)
+import Criterion.Main
+-- | This package
+import Logic.Expression
+
+-- Run all the benchmark tests
+main :: IO ()
+main = defaultMain [ interpretationBenchs [1..10] ]
+
+-- | Benchmark interpretations
+interpretationBenchs :: [Int] -> Benchmark
+interpretationBenchs ns = bgroup "interpretations" [ nQueensBench n | n<-ns  ]
+
+-- | Benchmark computing the interpretations of the nQueens puzzle.
+nQueensBench :: Int -> Benchmark
+nQueensBench n = bench ("nQueens("++show n++")") $ nf (interpretations . nQueens) n
+
+-- | Construct a list of expressions that are true if and only if the
+-- assignment is a solution to the n-queens problem.   Specifically, given an
+-- NxN chess board, how can you place N queens on the board such that none of
+-- them share the same row (rank), column (file), or diagonal.
+nQueens :: Int -> [Expr String]
+nQueens n = rankRules ++ fileRules ++ lDiagRules ++ rDiagRules
+    where
+    files = [1..n]
+    ranks = [1..n]
+    var (r,f) = variable $ (['a'..'z']!!(f-1)):show r
+    -- rank rule - there must be exactly one queen on each rank
+    rankRules = [ rankRule r | r<-ranks ]
+    rankRule r = (xors [ ands (var (r,f):[ not $ var (r,f') | f'<-files, f'/=f ]) | f<-files ]) `equals` true
+    -- file rule - there must be exactly one queen on each file
+    fileRules = [ fileRule f | f<-files ]
+    fileRule f = (xors [ ands (var(r,f):[ not $ var (r',f) | r'<-ranks, r'/=r ]) | r<-ranks ]) `equals` true
+    -- right Diagonal Rules - there is at most one queen on each right diagonal
+    rDiagRules  = [ (rDiagRule c) `equals` false | c<-[-(n-2) .. (n-2)]]
+    rDiagRule c = ors [var (f+c,f) `and` (ors [var (f'+c,f') | f'<-files,f'>f,c+f'<=n,c+f'>0]) | f<-files, f+c<=n, c+f>0]
+    -- right Diagonal Rules - there is at most one queen on each left diagonal
+    lDiagRules  = [ (lDiagRule c) `equals` false | c<-[3 .. 2*n-1]]
+    lDiagRule c = ors [ var (c-f,f) `and` (ors [var (c-f',f') | f'<-files,f'>f,c-f'<=n,c-f'>0]) | f<-files, c-f<=n, c-f>0]

--- a/simple-sat.cabal
+++ b/simple-sat.cabal
@@ -28,7 +28,7 @@ executable simple-sat
 library
   hs-source-dirs:      src
   exposed-modules:     Logic.Expression, Logic.Syntax
-  other-modules:       Logic.Expression.Internal
+  other-modules:       Logic.Expression.Internal,Text.Pretty
   build-depends:       base, vector, containers, attoparsec, text
   default-language:    Haskell2010
   ghc-options:         -O2 -Wall -Werror
@@ -44,6 +44,15 @@ test-suite simple-sat-test
                        , simple-sat
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   default-language:    Haskell2010
+
+benchmark simple-sat-benchmark
+    hs-source-dirs: bench
+    main-is: Bench.hs
+    build-depends:    base, QuickCheck, random, criterion, simple-sat
+    type: exitcode-stdio-1.0
+    extra-libraries: blas
+    default-language: Haskell2010
+    ghc-options: -Wall -Werror -O2
 
 source-repository head
   type:     git

--- a/src/Logic/Expression/Internal.hs
+++ b/src/Logic/Expression/Internal.hs
@@ -5,9 +5,9 @@ module Logic.Expression.Internal(
     Internal,
     true, false,
     variable,
-    xor, and, ands, xors, or, equals, implies, not,
+    xor, and, ands, xors, or, equals, implies, not, ors,
     -- Satisfiability
-    isSat, interpretations, assign,
+    isSat, interpretations, assign, identifiers
     ) where
 
 import           Data.Set(Set)
@@ -64,8 +64,14 @@ implies p q = (p `and` q) `xor` p `xor` true
 -- | O(n) - construct the logical negation of an expression.  Terms will
 -- be arranged in descending term order.
 not :: Internal -> Internal
+{-# INLINE not #-}
 not p = p `xor` true
 
+-- | O(n^2) - construct the n-ary disjunctin of a list of expressions.  Terms
+-- will be expressed in descending term order.
+ors :: [ Internal ] -> Internal
+{-# INLINE ors #-}
+ors = foldr or false
 
 -- | O(n) - construct the exclusive disjunction of two expressions.  Terms will
 -- be arranged in descending term order.

--- a/src/Text/Pretty.hs
+++ b/src/Text/Pretty.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+module Text.Pretty( Pretty(..)) where
+
+class Pretty m where
+    pretty :: m -> String
+    pretty = prettyTab 0
+    prettyTab :: Int -> m -> String
+    prettyPrint :: m -> IO ()
+    prettyPrint  = putStrLn . pretty
+
+instance {-# OVERLAPPING #-} Pretty String where
+    prettyTab _ s =  s
+
+instance Pretty Char where
+    prettyTab _ c =  [c]
+
+instance {-# OVERLAPPABLE #-} (Pretty a, Ord a) => Pretty [a] where
+    prettyTab n0 s
+        | null s = "[ ]"
+        | otherwise = "[ " ++ aux (n0+2) s ++ " ]"
+        where aux n (x:[]) = prettyTab n x
+              aux n (x:xs) = prettyTab n x ++ '\n':take n (repeat ' ') ++ aux n xs
+              aux _ _  = error "The unexpected happened"
+
+instance Pretty a => Pretty (Maybe a) where
+    prettyTab _ Nothing = "Nothing"
+    prettyTab n (Just a) = "Just " ++ prettyTab (n+5) a
+
+instance Pretty Int where
+    prettyTab _ n = show n
+
+instance (Pretty a, Pretty b) => Pretty (a,b) where
+    prettyTab n (a, b) = "( "++prettyTab n a ++ " , " ++ prettyTab n b ++" )"


### PR DESCRIPTION
ISSUE #15 - Verify that operations preserve term ordering
- Added predicate and unit tests to confirm that the logical operations preserve the term ordering
ISSUE #2 - added pretty printer for the Expression datatype
ISSUE #8 - introduced benchmark suite.   It can be invoked from the command line using the 
    following:
```bash
$ stack bench
```
doing so will cause it to construct expressions representing the n queens problem for values of n between 1 and 10 and benchmark the interpretations function for each set of expressions.